### PR TITLE
Publishing Pose and Detection

### DIFF
--- a/src/dependencies/custom_msgs/CMakeLists.txt
+++ b/src/dependencies/custom_msgs/CMakeLists.txt
@@ -22,6 +22,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Heading.msg"
   "msg/ArucoPose.msg"
   "msg/ConfidenceLevel.msg"
+  "msg/ValveDetection.msg"
   DEPENDENCIES sensor_msgs std_msgs geometry_msgs
 )
 

--- a/src/dependencies/custom_msgs/msg/ValveDetection.msg
+++ b/src/dependencies/custom_msgs/msg/ValveDetection.msg
@@ -1,0 +1,15 @@
+std_msgs/Header header
+
+string  class_name    # detected class label (e.g. "valve")
+float32 confidence    # YOLO detection confidence [0, 1]
+
+# 3-D centroid of the fitted AABB in camera frame [m]
+# ZED RIGHT_HANDED_Y_UP: X=right, Y=up, Z=toward camera (negative = in front)
+float32 x
+float32 y
+float32 z
+
+# Axis-aligned bounding box dimensions [m]
+float32 length        # extent along X
+float32 breadth       # extent along Y
+float32 height        # extent along Z (depth)

--- a/src/mira2_perception/scripts/zed_3d_bbox.py
+++ b/src/mira2_perception/scripts/zed_3d_bbox.py
@@ -24,6 +24,11 @@ import numpy as np
 import pyzed.sl as sl
 from ultralytics import YOLO
 
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import PoseStamped
+from custom_msgs.msg import ValveDetection
+
 try:
     from ament_index_python.packages import get_package_share_directory
     _PKG_SHARE = get_package_share_directory("mira2_perception")
@@ -211,6 +216,12 @@ def main():
     target = args.target.lower()
     model  = YOLO(args.model)
 
+    # ── ROS 2 setup ───────────────────────────────────────────────────────
+    rclpy.init()
+    ros_node = Node('valve_3d_bbox_node')
+    det_pub  = ros_node.create_publisher(ValveDetection, '/valve/detection', 10)
+    pose_pub = ros_node.create_publisher(PoseStamped,    '/valve/pose',      10)
+
     state = SharedState()
     t     = threading.Thread(target=zed_worker, args=(args, state), daemon=True)
     t.start()
@@ -301,6 +312,30 @@ def main():
                                 cv2.FONT_HERSHEY_SIMPLEX, 0.52, CLR_XYZ, 2)
                     cv2.putText(img, size_line, (bx1, by2+40),
                                 cv2.FONT_HERSHEY_SIMPLEX, 0.52, CLR_XYZ, 2)
+
+                    # ── publish custom message ─────────────────────────────
+                    stamp = ros_node.get_clock().now().to_msg()
+
+                    det = ValveDetection()
+                    det.header.stamp    = stamp
+                    det.header.frame_id = 'zed_left_camera_frame'
+                    det.class_name      = cls_name
+                    det.confidence      = conf_val
+                    det.x, det.y, det.z = float(x3), float(y3), float(z3)
+                    det.length          = float(W)
+                    det.breadth         = float(H)
+                    det.height          = float(D)
+                    det_pub.publish(det)
+
+                    # /valve/pose for the controls node (camera frame)
+                    pose = PoseStamped()
+                    pose.header.stamp    = stamp
+                    pose.header.frame_id = 'zed_left_camera_frame'
+                    pose.pose.position.x = float(x3)
+                    pose.pose.position.y = float(y3)
+                    pose.pose.position.z = float(z3)
+                    pose.pose.orientation.w = 1.0
+                    pose_pub.publish(pose)
                 else:
                     cv2.putText(img, "not enough depth pts",
                                 (bx1, by2+20),
@@ -344,6 +379,8 @@ def main():
         state.stop = True
     t.join(timeout=3)
     cv2.destroyAllWindows()
+    ros_node.destroy_node()
+    rclpy.shutdown()
     print("[INFO] Done.")
 
 


### PR DESCRIPTION
## Summary
- Registers `ValveDetection.msg` in `custom_msgs` CMakeLists so it is generated at build time
- Initialises a ROS 2 node inside `zed_3d_bbox.py` and publishes on two topics:
  - `/valve/detection` (`custom_msgs/ValveDetection`): class name, confidence, 3D bounding box dimensions, and XYZ centroid in the ZED left camera frame
  - `/valve/pose` (`geometry_msgs/PoseStamped`): XYZ position of the detected valve in the ZED left camera frame, intended for the controls node

## Test plan
- [ ] Build `custom_msgs` and confirm `ValveDetection` message is generated without errors
- [ ] Run `zed_3d_bbox.py` with a ZED camera and YOLO model; verify `/valve/detection` and `/valve/pose` topics appear (`ros2 topic list`)
- [ ] Echo both topics and confirm data updates with each detection frame
- [ ] Confirm the node shuts down cleanly (no rclpy errors on Ctrl+C)